### PR TITLE
Use `AnchoredPath` to guard against escaping relative paths :gear: 

### DIFF
--- a/src/hoarder/archives/abstract_rar_archive.py
+++ b/src/hoarder/archives/abstract_rar_archive.py
@@ -58,18 +58,17 @@ class AbstractRarArchive(HashArchive, abc.ABC):
             raise ValueError(f"Invalid number of volumes for {self.full_path}")
         if self.n_volumes == 1:
             return [self.full_path]
+        volume_dir = self.full_path.parent
         if self.scheme == RarScheme.DOT_RNN:
-            return [
-                self.anchor.storage_path / f"{self.anchor.relative_path.stem}.rar"
-            ] + [
-                self.anchor.storage_path
-                / f"{self.anchor.relative_path.stem}.r{index:02d}"
+            stem = self.anchor.relative_path.stem
+            return [volume_dir / f"{stem}.rar"] + [
+                volume_dir / f"{stem}.r{index:02d}"
                 for index in range(0, self.n_volumes - 1)
             ]
         if self.scheme == RarScheme.PART_N:
             stem = self.anchor.relative_path.stem.split(".part")[0]
             volume_list = [
-                self.anchor.storage_path / f"{stem}.part{index}.rar"
+                volume_dir / f"{stem}.part{index}.rar"
                 for index in range(1, self.n_volumes + 1)
             ]
             for p in volume_list:

--- a/src/hoarder/archives/abstract_rar_archive.py
+++ b/src/hoarder/archives/abstract_rar_archive.py
@@ -59,14 +59,17 @@ class AbstractRarArchive(HashArchive, abc.ABC):
         if self.n_volumes == 1:
             return [self.full_path]
         if self.scheme == RarScheme.DOT_RNN:
-            return [self.storage_path / f"{self.path.stem}.rar"] + [
-                self.storage_path / f"{self.path.stem}.r{index:02d}"
+            return [
+                self.anchor.storage_path / f"{self.anchor.relative_path.stem}.rar"
+            ] + [
+                self.anchor.storage_path
+                / f"{self.anchor.relative_path.stem}.r{index:02d}"
                 for index in range(0, self.n_volumes - 1)
             ]
         if self.scheme == RarScheme.PART_N:
-            stem = self.path.stem.split(".part")[0]
+            stem = self.anchor.relative_path.stem.split(".part")[0]
             volume_list = [
-                self.storage_path / f"{stem}.part{index}.rar"
+                self.anchor.storage_path / f"{stem}.part{index}.rar"
                 for index in range(1, self.n_volumes + 1)
             ]
             for p in volume_list:

--- a/src/hoarder/archives/hash_archive.py
+++ b/src/hoarder/archives/hash_archive.py
@@ -13,6 +13,7 @@ try:
 except ImportError:
     from typing_extensions import override
 
+from hoarder.utils.path_utils import AnchoredPath
 from hoarder.utils.presentation import PresentationSpec, ScalarValue
 
 
@@ -62,8 +63,7 @@ T = typing.TypeVar("T", bound="HashArchive")
 class HashArchive(abc.ABC):
     """This class contains information about an hash file."""
 
-    storage_path: pathlib.Path
-    path: pathlib.PurePath
+    anchor: AnchoredPath
     files: set[FileEntry]
     is_deleted: bool
     info: str | None = None
@@ -87,14 +87,13 @@ class HashArchive(abc.ABC):
             files: Optional set of FileEntry objects
         """
         self.files = files or set()
-        self.storage_path = storage_path.resolve()
-        self.path = path
+        self.anchor = AnchoredPath(storage_path, path)
         self.is_deleted = True
 
     @property
     def full_path(self) -> pathlib.Path:
         """Calculate the full path by combining storage_path and path."""
-        return self.storage_path / self.path
+        return self.anchor.full_path
 
     @classmethod
     def from_path(
@@ -167,7 +166,7 @@ class HashArchive(abc.ABC):
             "path": str(self.full_path),
         }
         header_fields = self._printable_attributes()
-        excluded_fields = {"files", "path", "storage_path"}
+        excluded_fields = {"files", "anchor"}
         for attr in filter(lambda a: a not in excluded_fields, header_fields):
             scalar[attr] = getattr(self, attr)
 

--- a/src/hoarder/archives/hash_archive_repository.py
+++ b/src/hoarder/archives/hash_archive_repository.py
@@ -16,7 +16,7 @@ class HashArchiveRepository:
 
     def save(self, archive: HashArchive, con: sqlite3.Connection) -> None:
         """Insert or replace one archive and all its FileEntry rows."""
-        storage_path_str = str(archive.storage_path.resolve())
+        storage_path_str = str(archive.anchor.storage_path)
 
         archive_row = self._build_archive_row(archive)
         archive_path_str = str(archive_row["path"])
@@ -136,7 +136,7 @@ class HashArchiveRepository:
         """Return a dict used directly with named-parameter SQL."""
         base: dict[str, str | int | None] = {
             "type": type(arch).__name__,
-            "path": str(arch.path),
+            "path": str(arch.anchor.relative_path),
             "is_deleted": int(arch.is_deleted),
             "hash_enclosure": None,
             "password": None,

--- a/src/hoarder/archives/rar_archive_7z.py
+++ b/src/hoarder/archives/rar_archive_7z.py
@@ -133,7 +133,7 @@ class Rar7zArchive(AbstractRarArchive):
         logger.debug(
             "Processing archive %(name)s with path %(entry_path)s using password %(password)s",
             {
-                "name": self.path.name,
+                "name": self.anchor.relative_path.name,
                 "entry_path": entry_path,
                 "password": self.password,
             },
@@ -160,12 +160,16 @@ class Rar7zArchive(AbstractRarArchive):
         if not crc_match:
             logger.error(
                 "Failed to get CRC for %(name)s: %(entry_path)s",
-                {"name": self.path.name, "entry_path": entry_path},
+                {"name": self.anchor.relative_path.name, "entry_path": entry_path},
             )
             return None
         logger.debug(
             "Got CRC %(crc_match)s for %(name)s: %(entry_path)s",
-            {"crc_match": crc_match, "name": self.path.name, "entry_path": entry_path},
+            {
+                "crc_match": crc_match,
+                "name": self.anchor.relative_path.name,
+                "entry_path": entry_path,
+            },
         )
         return bytes.fromhex(crc_match)
 

--- a/src/hoarder/downloads/download_repository.py
+++ b/src/hoarder/downloads/download_repository.py
@@ -34,13 +34,13 @@ class DownloadRepository:
         """Insert or replace a Download and its associated RealFiles and HashArchives."""
         # Ensure storage paths exist for all real_files
         for real_file in download.real_files:
-            self._ensure_storage_path(con, real_file.storage_path)
+            self._ensure_storage_path(con, real_file.anchor.storage_path)
             for verification in real_file.verification:
-                self._ensure_storage_path(con, verification.source_storage_path)
+                self._ensure_storage_path(con, verification.source.storage_path)
 
         # Ensure storage paths exist for all hash_archives
         for hash_archive in download.hash_archives:
-            self._ensure_storage_path(con, hash_archive.storage_path)
+            self._ensure_storage_path(con, hash_archive.anchor.storage_path)
 
         # Save all real_files first using real_file_repository
         for real_file in download.real_files:
@@ -209,8 +209,8 @@ class DownloadRepository:
         for real_file in real_files:
             yield {
                 "download_title": download_title,
-                "real_file_storage_path": str(real_file.storage_path.resolve()),
-                "real_file_path": str(real_file.path),
+                "real_file_storage_path": str(real_file.anchor.storage_path),
+                "real_file_path": str(real_file.anchor.relative_path),
             }
 
     def _build_archive_association_rows(
@@ -222,8 +222,8 @@ class DownloadRepository:
         for hash_archive in hash_archives:
             yield {
                 "download_title": download_title,
-                "archive_storage_path": str(hash_archive.storage_path.resolve()),
-                "archive_path": str(hash_archive.path),
+                "archive_storage_path": str(hash_archive.anchor.storage_path),
+                "archive_path": str(hash_archive.anchor.relative_path),
             }
 
     def _load_real_files(

--- a/src/hoarder/downloads/real_file.py
+++ b/src/hoarder/downloads/real_file.py
@@ -7,6 +7,7 @@ from pathlib import Path, PurePath
 from typing import ClassVar, Type
 
 from ..archives import Algo
+from ..utils import AnchoredPath
 from .contents_hasher import ContentsHasher, CRC32Hasher
 
 
@@ -24,8 +25,7 @@ class VerificationSource(enum.IntEnum):
 class RealFile:
     """Represents a file or directory we encountered in storage."""
 
-    storage_path: Path
-    path: PurePath
+    anchor: AnchoredPath
     size: int
     is_dir: bool
     algo: Algo | None = None
@@ -46,7 +46,7 @@ class RealFile:
     @property
     def full_path(self) -> Path:
         """Return the resolved path on disk."""
-        return self.storage_path / self.path
+        return self.anchor.full_path
 
     def calculate_hash(self, algo: Algo = Algo.CRC32) -> bytes:
         """Calculate and assign hash/algo for this real file."""
@@ -72,16 +72,14 @@ class RealFile:
         algo: Algo = Algo.CRC32,
     ) -> RealFile:
         """Create a RealFile instance by inspecting the filesystem."""
-        storage_path = Path(storage_path)
-        pure_path = PurePath(path)
-        full_path = storage_path / pure_path
+        anchor = AnchoredPath(Path(storage_path), PurePath(path))
+        full_path = anchor.full_path
         if not full_path.exists():
             raise FileNotFoundError(full_path)
 
         stat = full_path.stat()
         real_file = cls(
-            storage_path=storage_path,
-            path=pure_path,
+            anchor=anchor,
             size=stat.st_size,
             is_dir=full_path.is_dir(),
         )
@@ -97,8 +95,7 @@ class Verification:
 
     real_file: RealFile
     source_type: VerificationSource
-    source_path: PurePath
-    source_storage_path: Path
+    source: AnchoredPath
     hash_value: bytes
     algo: Algo
     comment: str | None = None

--- a/src/hoarder/downloads/real_file_repository.py
+++ b/src/hoarder/downloads/real_file_repository.py
@@ -142,12 +142,12 @@ class RealFileRepository:
             "is_dir": int(real_file.is_dir),
             "hash_value": real_file.hash_value,
             "algo": real_file.algo.value if real_file.algo is not None else None,
-            "first_seen": real_file.first_seen.isoformat()
-            if real_file.first_seen
-            else None,
-            "last_seen": real_file.last_seen.isoformat()
-            if real_file.last_seen
-            else None,
+            "first_seen": (
+                real_file.first_seen.isoformat() if real_file.first_seen else None
+            ),
+            "last_seen": (
+                real_file.last_seen.isoformat() if real_file.last_seen else None
+            ),
             "comment": real_file.comment,
         }
 

--- a/src/hoarder/downloads/real_file_repository.py
+++ b/src/hoarder/downloads/real_file_repository.py
@@ -7,6 +7,7 @@ from pathlib import Path, PurePath
 from typing import Iterable
 
 from ..archives import Algo
+from ..utils import AnchoredPath
 from .real_file import RealFile, Verification, VerificationSource
 
 
@@ -15,10 +16,10 @@ class RealFileRepository:
 
     def save(self, real_file: RealFile, con: sqlite3.Connection) -> None:
         """Insert or replace a RealFile and its verifications."""
-        storage_path_str = str(real_file.storage_path.resolve())
+        storage_path_str = str(real_file.anchor.storage_path)
         real_file_row = self._build_real_file_row(real_file)
 
-        self._ensure_storage_path(con, real_file.storage_path)
+        self._ensure_storage_path(con, real_file.anchor.storage_path)
         cur = con.cursor()
         _ = cur.execute(
             """
@@ -26,7 +27,7 @@ class RealFileRepository:
             WHERE storage_path_id = (SELECT id FROM storage_paths WHERE storage_path = ?)
               AND path = ?;
             """,
-            (storage_path_str, str(real_file.path)),
+            (storage_path_str, str(real_file.anchor.relative_path)),
         )
         _ = cur.execute(
             """
@@ -57,11 +58,11 @@ class RealFileRepository:
         )
         if real_file.verification:
             for verification in real_file.verification:
-                self._ensure_storage_path(con, verification.source_storage_path)
+                self._ensure_storage_path(con, verification.source.storage_path)
             verification_rows = list(
                 self._build_verification_rows(
                     real_file.verification,
-                    str(real_file.path),
+                    str(real_file.anchor.relative_path),
                     storage_path_str,
                 )
             )
@@ -136,7 +137,7 @@ class RealFileRepository:
     @staticmethod
     def _build_real_file_row(real_file: RealFile) -> dict[str, object]:
         return {
-            "path": str(real_file.path),
+            "path": str(real_file.anchor.relative_path),
             "size": real_file.size,
             "is_dir": int(real_file.is_dir),
             "hash_value": real_file.hash_value,
@@ -159,8 +160,8 @@ class RealFileRepository:
         for verification in verifications:
             yield {
                 "source_type": verification.source_type.value,
-                "source_path": str(verification.source_path),
-                "source_storage_path": str(verification.source_storage_path.resolve()),
+                "source_path": str(verification.source.relative_path),
+                "source_storage_path": str(verification.source.storage_path),
                 "hash_value": verification.hash_value,
                 "algo": verification.algo.value,
                 "comment": verification.comment,
@@ -192,8 +193,9 @@ class RealFileRepository:
             verification = Verification(
                 real_file=real_file,
                 source_type=VerificationSource(row["source_type"]),
-                source_path=PurePath(row["source_path"]),
-                source_storage_path=Path(row["source_storage_path"]),
+                source=AnchoredPath(
+                    Path(row["source_storage_path"]), PurePath(row["source_path"])
+                ),
                 hash_value=row["hash_value"],
                 algo=Algo(row["algo"]),
                 comment=row["comment"],
@@ -212,8 +214,7 @@ class RealFileRepository:
     @staticmethod
     def _row_to_real_file(row: sqlite3.Row) -> RealFile:
         return RealFile(
-            storage_path=Path(row["storage_path"]),
-            path=PurePath(row["path"]),
+            anchor=AnchoredPath(Path(row["storage_path"]), PurePath(row["path"])),
             size=int(row["size"]),
             is_dir=bool(row["is_dir"]),
             algo=Algo(row["algo"]) if row["algo"] is not None else None,

--- a/src/hoarder/hoarder_repository.py
+++ b/src/hoarder/hoarder_repository.py
@@ -31,7 +31,9 @@ class HoarderRepository:
         self._initialize_password_tables()
 
     def save_hash_archive(self, archive: HashArchive) -> None:
-        normalized_storage_path = self._check_storage_path_allowed(archive.storage_path)
+        normalized_storage_path = self._check_storage_path_allowed(
+            archive.anchor.storage_path
+        )
         with Sqlite3FK(self.db_path) as con:
             self._ensure_storage_path(con, normalized_storage_path)
             self.hash_repo.save(archive, con)
@@ -46,11 +48,11 @@ class HoarderRepository:
 
     def save_real_file(self, real_file: RealFile) -> None:
         normalized_storage_path = self._check_storage_path_allowed(
-            real_file.storage_path
+            real_file.anchor.storage_path
         )
         for verification in real_file.verification:
-            verification.source_storage_path = self._check_storage_path_allowed(
-                verification.source_storage_path
+            verification.source = verification.source.with_storage_path(
+                self._check_storage_path_allowed(verification.source.storage_path)
             )
         with Sqlite3FK(self.db_path) as con:
             self._ensure_storage_path(con, normalized_storage_path)
@@ -76,25 +78,29 @@ class HoarderRepository:
         # Validate storage paths from real_files
         for real_file in download.real_files:
             normalized_storage_path = self._check_storage_path_allowed(
-                real_file.storage_path
+                real_file.anchor.storage_path
             )
-            real_file.storage_path = normalized_storage_path
+            real_file.anchor = real_file.anchor.with_storage_path(
+                normalized_storage_path
+            )
             for verification in real_file.verification:
-                verification.source_storage_path = self._check_storage_path_allowed(
-                    verification.source_storage_path
+                verification.source = verification.source.with_storage_path(
+                    self._check_storage_path_allowed(verification.source.storage_path)
                 )
         # Validate storage paths from hash_archives
         for hash_archive in download.hash_archives:
             normalized_storage_path = self._check_storage_path_allowed(
-                hash_archive.storage_path
+                hash_archive.anchor.storage_path
             )
-            hash_archive.storage_path = normalized_storage_path
+            hash_archive.anchor = hash_archive.anchor.with_storage_path(
+                normalized_storage_path
+            )
         with Sqlite3FK(self.db_path) as con:
             # Ensure all storage paths exist
             for real_file in download.real_files:
-                self._ensure_storage_path(con, real_file.storage_path)
+                self._ensure_storage_path(con, real_file.anchor.storage_path)
             for hash_archive in download.hash_archives:
-                self._ensure_storage_path(con, hash_archive.storage_path)
+                self._ensure_storage_path(con, hash_archive.anchor.storage_path)
             self.download_repo.save(download, con)
 
     def load_download(self, title: str) -> Download:

--- a/src/hoarder/utils/__init__.py
+++ b/src/hoarder/utils/__init__.py
@@ -1,6 +1,6 @@
 from . import db_schema, db_utils, path_utils, presentation, shared, sql3_fk
 from .db_utils import now_str
-from .path_utils import PathType, determine_path_type
+from .path_utils import AnchoredPath, PathType, determine_path_type
 from .presentation import Presentable, PresentationSpec, ScalarValue, TableFormatter
 from .shared import SEVENZIP, config
 from .sql3_fk import Sqlite3FK
@@ -18,6 +18,7 @@ __all__ = [
     "Sqlite3FK",
     "TableFormatter",
     "now_str",
+    "AnchoredPath",
     "PathType",
     "determine_path_type",
     "SEVENZIP",

--- a/src/hoarder/utils/path_utils.py
+++ b/src/hoarder/utils/path_utils.py
@@ -1,3 +1,4 @@
+import dataclasses
 import enum
 import pathlib
 
@@ -21,3 +22,44 @@ def determine_path_type(path: str | pathlib.Path) -> PathType:
         return PathType.POSIX
     else:
         return PathType.AMBIVALENT
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class AnchoredPath:
+    """A relative_path anchored to a storage_path.
+
+    Guarantees at construction (and on every replacement) that the combination
+    cannot resolve outside storage_path.
+    """
+
+    storage_path: pathlib.Path
+    relative_path: pathlib.PurePath
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self, "storage_path", pathlib.Path(self.storage_path).resolve()
+        )
+        object.__setattr__(
+            self, "relative_path", pathlib.PurePath(self.relative_path)
+        )
+        resolved = (self.storage_path / self.relative_path).resolve()
+        if not resolved.is_relative_to(self.storage_path):
+            raise ValueError(
+                f"Path '{self.relative_path}' escapes storage root '{self.storage_path}'"
+            )
+
+    @property
+    def full_path(self) -> pathlib.Path:
+        return self.storage_path / self.relative_path
+
+    def with_storage_path(self, storage_path: pathlib.Path | str) -> "AnchoredPath":
+        """Return a new, revalidated AnchoredPath with a different storage_path."""
+        return dataclasses.replace(self, storage_path=pathlib.Path(storage_path))
+
+    @classmethod
+    def from_absolute_path(
+        cls, storage_path: pathlib.Path | str, absolute_path: pathlib.Path | str
+    ) -> "AnchoredPath":
+        sp = pathlib.Path(storage_path).resolve()
+        ap = pathlib.Path(absolute_path).resolve()
+        return cls(sp, ap.relative_to(sp))

--- a/src/hoarder/utils/path_utils.py
+++ b/src/hoarder/utils/path_utils.py
@@ -39,9 +39,7 @@ class AnchoredPath:
         object.__setattr__(
             self, "storage_path", pathlib.Path(self.storage_path).resolve()
         )
-        object.__setattr__(
-            self, "relative_path", pathlib.PurePath(self.relative_path)
-        )
+        object.__setattr__(self, "relative_path", pathlib.PurePath(self.relative_path))
         resolved = (self.storage_path / self.relative_path).resolve()
         if not resolved.is_relative_to(self.storage_path):
             raise ValueError(

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import pytest
 from hoarder.downloads import Download, RealFile
+from hoarder.utils import AnchoredPath
 
 FROZEN_TS = dt.datetime(2024, 1, 1, tzinfo=dt.timezone.utc)
 
@@ -33,14 +34,12 @@ def test_download_with_real_files() -> None:
     """Test Download with associated RealFiles."""
     storage_path = Path("/test/storage")
     real_file1 = RealFile(
-        storage_path=storage_path,
-        path=Path("file1.dat"),
+        anchor=AnchoredPath(storage_path, Path("file1.dat")),
         size=100,
         is_dir=False,
     )
     real_file2 = RealFile(
-        storage_path=storage_path,
-        path=Path("file2.bin"),
+        anchor=AnchoredPath(storage_path, Path("file2.bin")),
         size=200,
         is_dir=False,
     )

--- a/tests/test_download_repository.py
+++ b/tests/test_download_repository.py
@@ -106,7 +106,9 @@ def test_download_repository_roundtrip(
             if rf.anchor.relative_path == sample_original.anchor.relative_path
         )
         assert sample_loaded.anchor.storage_path == sample_original.anchor.storage_path
-        assert sample_loaded.anchor.relative_path == sample_original.anchor.relative_path
+        assert (
+            sample_loaded.anchor.relative_path == sample_original.anchor.relative_path
+        )
         assert sample_loaded.size == sample_original.size
         assert sample_loaded.hash_value == sample_original.hash_value
     assert sample_loaded.first_seen == sample_original.first_seen
@@ -291,4 +293,6 @@ def test_download_repository_persists_real_files_and_hash_archives(
 
     assert len(loaded.real_files) == len(test_files)
     assert len(loaded.hash_archives) == 1
-    assert loaded.hash_archives[0].anchor.relative_path == sfv_archive.anchor.relative_path
+    assert (
+        loaded.hash_archives[0].anchor.relative_path == sfv_archive.anchor.relative_path
+    )

--- a/tests/test_download_repository.py
+++ b/tests/test_download_repository.py
@@ -7,6 +7,7 @@ import pytest
 from hoarder import HoarderRepository
 from hoarder.archives import SfvArchive
 from hoarder.downloads import Download, RealFile
+from hoarder.utils import AnchoredPath
 
 FROZEN_TS = dt.datetime(2024, 1, 1, tzinfo=dt.timezone.utc)
 
@@ -51,7 +52,7 @@ def _collect_files_from_directory(
             real_file.last_seen = FROZEN_TS
             real_files.append(real_file)
 
-    return sorted(real_files, key=lambda rf: str(rf.path))
+    return sorted(real_files, key=lambda rf: str(rf.anchor.relative_path))
 
 
 def _build_download(title: str, real_files: list[RealFile]) -> Download:
@@ -92,18 +93,20 @@ def test_download_repository_roundtrip(
     assert len(loaded.real_files) == len(real_files)
 
     # Verify all real_files are present and correct
-    loaded_paths = {rf.path for rf in loaded.real_files}
-    original_paths = {rf.path for rf in real_files}
+    loaded_paths = {rf.anchor.relative_path for rf in loaded.real_files}
+    original_paths = {rf.anchor.relative_path for rf in real_files}
     assert loaded_paths == original_paths
 
     # Verify a sample real_file has correct attributes
     if real_files:
         sample_original = real_files[0]
         sample_loaded = next(
-            rf for rf in loaded.real_files if rf.path == sample_original.path
+            rf
+            for rf in loaded.real_files
+            if rf.anchor.relative_path == sample_original.anchor.relative_path
         )
-        assert sample_loaded.storage_path == sample_original.storage_path
-        assert sample_loaded.path == sample_original.path
+        assert sample_loaded.anchor.storage_path == sample_original.anchor.storage_path
+        assert sample_loaded.anchor.relative_path == sample_original.anchor.relative_path
         assert sample_loaded.size == sample_original.size
         assert sample_loaded.hash_value == sample_original.hash_value
     assert sample_loaded.first_seen == sample_original.first_seen
@@ -132,7 +135,9 @@ def test_download_repository_persists_real_files(
     assert len(loaded.real_files) == len(test_files)
     for original_file in test_files:
         loaded_file = next(
-            rf for rf in loaded.real_files if rf.path == original_file.path
+            rf
+            for rf in loaded.real_files
+            if rf.anchor.relative_path == original_file.anchor.relative_path
         )
         assert loaded_file.size == original_file.size
         assert loaded_file.hash_value == original_file.hash_value
@@ -199,8 +204,7 @@ def test_download_repository_disallows_unknown_storage_path_on_save(
     """Test that saving a download with real_files from disallowed storage path raises ValueError."""
     disallowed_storage = compare_storage_path.parent
     real_file = RealFile(
-        storage_path=disallowed_storage,
-        path=Path("nonexistent.dat"),
+        anchor=AnchoredPath(disallowed_storage, Path("nonexistent.dat")),
         size=0,
         is_dir=False,
     )
@@ -252,8 +256,8 @@ def test_download_repository_persists_hash_archives(
 
     assert len(loaded.hash_archives) == 1
     loaded_archive = loaded.hash_archives[0]
-    assert loaded_archive.storage_path == sfv_archive.storage_path
-    assert loaded_archive.path == sfv_archive.path
+    assert loaded_archive.anchor.storage_path == sfv_archive.anchor.storage_path
+    assert loaded_archive.anchor.relative_path == sfv_archive.anchor.relative_path
     assert loaded_archive.__class__ == sfv_archive.__class__
     assert len(loaded_archive.files) == len(sfv_archive.files)
 
@@ -287,4 +291,4 @@ def test_download_repository_persists_real_files_and_hash_archives(
 
     assert len(loaded.real_files) == len(test_files)
     assert len(loaded.hash_archives) == 1
-    assert loaded.hash_archives[0].path == sfv_archive.path
+    assert loaded.hash_archives[0].anchor.relative_path == sfv_archive.anchor.relative_path

--- a/tests/test_hash_archive_repository.py
+++ b/tests/test_hash_archive_repository.py
@@ -57,7 +57,7 @@ def test_sfv_repositories(create_test_repo):
         saved_sfv_file = SfvArchive.from_path(root, path)
         create_test_repo.save_hash_archive(saved_sfv_file)
         retrieved_sfv_file = create_test_repo.load_hash_archive(
-            saved_sfv_file.storage_path, saved_sfv_file.path
+            saved_sfv_file.anchor.storage_path, saved_sfv_file.anchor.relative_path
         )
 
         print(saved_sfv_file)
@@ -89,7 +89,7 @@ def test_rar_repositories(
         pytest.skip(f"Required file not found: {exc}")
     create_test_repo.save_hash_archive(saved_rar_file)
     retrieved_rar_file = create_test_repo.load_hash_archive(
-        saved_rar_file.storage_path, saved_rar_file.path
+        saved_rar_file.anchor.storage_path, saved_rar_file.anchor.relative_path
     )
 
     assert repr(saved_rar_file) == repr(retrieved_rar_file)
@@ -108,7 +108,7 @@ def test_hnf_repositories(create_test_repo):
         saved_hnf_file = HashNameArchive.from_path(root, path)
         create_test_repo.save_hash_archive(saved_hnf_file)
         retrieved_hnf_file = create_test_repo.load_hash_archive(
-            saved_hnf_file.storage_path, saved_hnf_file.path
+            saved_hnf_file.anchor.storage_path, saved_hnf_file.anchor.relative_path
         )
 
     assert repr(saved_hnf_file) == repr(retrieved_hnf_file)

--- a/tests/test_real_file.py
+++ b/tests/test_real_file.py
@@ -6,6 +6,7 @@ import pytest
 import tests.test_case_file_info as case_files
 from hoarder.archives import Algo
 from hoarder.downloads import RealFile
+from hoarder.utils import AnchoredPath
 
 STORAGE_ROOT = Path("test_files/compare")
 CRC32_SAMPLE_FILES = [fe for fe in case_files.TEST_FILES if not fe.is_dir][:10]
@@ -14,8 +15,7 @@ CRC32_SAMPLE_DIRS = [fe for fe in case_files.TEST_FILES if fe.is_dir][:5]
 
 def _build_real_file(entry: case_files.FileEntry) -> RealFile:
     return RealFile(
-        storage_path=STORAGE_ROOT,
-        path=entry.path,
+        anchor=AnchoredPath(STORAGE_ROOT, entry.path),
         size=entry.size,
         is_dir=entry.is_dir,
     )
@@ -24,7 +24,7 @@ def _build_real_file(entry: case_files.FileEntry) -> RealFile:
 def test_real_file_full_path_includes_storage_root() -> None:
     entry = case_files.TEST_FILES[0]
     real_file = _build_real_file(entry)
-    assert real_file.full_path == STORAGE_ROOT / entry.path
+    assert real_file.full_path == STORAGE_ROOT.resolve() / entry.path
 
 
 @pytest.mark.parametrize("entry", CRC32_SAMPLE_FILES)

--- a/tests/test_real_file_repository.py
+++ b/tests/test_real_file_repository.py
@@ -8,6 +8,7 @@ import tests.test_case_file_info as case_files
 from hoarder import HoarderRepository
 from hoarder.archives import Algo
 from hoarder.downloads import RealFile, Verification, VerificationSource
+from hoarder.utils import AnchoredPath
 
 FROZEN_TS = dt.datetime(2024, 1, 1, tzinfo=dt.timezone.utc)
 
@@ -54,8 +55,8 @@ def test_real_file_repository_roundtrip(
 
     loaded = hoarder_repo.load_real_file(compare_storage_path, "compare" / entry.path)
 
-    assert loaded.storage_path == compare_storage_path
-    assert loaded.path == "compare" / entry.path
+    assert loaded.anchor.storage_path == compare_storage_path
+    assert loaded.anchor.relative_path == "compare" / entry.path
     assert loaded.size == original.size
     assert loaded.hash_value == original.hash_value
     assert loaded.first_seen == FROZEN_TS
@@ -73,8 +74,7 @@ def test_real_file_repository_persists_verifications(
     verification = Verification(
         real_file=real_file,
         source_type=VerificationSource.ARCHIVE,
-        source_path=PurePath("compare") / entry.path,
-        source_storage_path=compare_storage_path,
+        source=AnchoredPath(compare_storage_path, PurePath("compare") / entry.path),
         hash_value=real_file.hash_value or b"",
         algo=real_file.algo or Algo.CRC32,
         comment="verified from archive",
@@ -87,8 +87,7 @@ def test_real_file_repository_persists_verifications(
     assert len(loaded.verification) == 1
     loaded_verification = loaded.verification[0]
     assert loaded_verification.source_type is VerificationSource.ARCHIVE
-    assert loaded_verification.source_path == verification.source_path
-    assert loaded_verification.source_storage_path == verification.source_storage_path
+    assert loaded_verification.source == verification.source
     assert loaded_verification.hash_value == verification.hash_value
     assert loaded_verification.algo == verification.algo
     assert loaded_verification.comment == "verified from archive"
@@ -100,8 +99,7 @@ def test_real_file_repository_disallows_unknown_storage_path_on_save(
 ) -> None:
     disallowed_storage = compare_storage_path.parent
     real_file = RealFile(
-        storage_path=disallowed_storage,
-        path=PurePath("nonexistent.dat"),
+        anchor=AnchoredPath(disallowed_storage, PurePath("nonexistent.dat")),
         size=0,
         is_dir=False,
         algo=None,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced an anchored path model for archives and files for consistent storage-root validation and full-path resolution.
  * Exposed `AnchoredPath` in the public utilities API.
* **Bug Fixes**
  * Improved RAR volume path construction and CRC32 missing-match logging context.
  * Corrected archive/download persistence and associations to consistently store and reload anchored storage/relative paths.
* **Refactor**
  * Updated archives, downloads, and repositories to use anchored paths end-to-end.
* **Tests**
  * Updated tests to construct and assert entities using the new anchored-path API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->