### PR TITLE
`NzbPasswordPlugin`: continue password extraction afte exception, improve type robustness :gear: 

### DIFF
--- a/src/hoarder/passwords/nzb_password_plugin.py
+++ b/src/hoarder/passwords/nzb_password_plugin.py
@@ -8,6 +8,7 @@ import traceback
 import xml.etree.ElementTree as ET
 from typing import Callable, NamedTuple
 
+from ..archives import RarArchiveError
 from ..archives.rar_archive import RarArchive
 from ..utils import TableFormatter
 from .password_plugin import PasswordPlugin
@@ -45,14 +46,18 @@ class NzbPasswordPlugin(PasswordPlugin):
 
         Raises:
             KeyError: If 'nzb_paths' is not present in the config dictionary.
+            TypeError: If 'nzb_paths' is not a list.
             ValueError: If 'nzb_paths' is empty.
             NotADirectoryError: If any path in 'nzb_paths' is not a valid directory.
         """
         if "nzb_paths" not in config:
             raise KeyError("nzb_paths not set")
-        if not config["nzb_paths"]:
-            raise ValueError("nzb_paths must map to a list")
-        paths = [pathlib.Path(p) for p in config["nzb_paths"]]
+        nzb_paths = config["nzb_paths"]
+        if not isinstance(nzb_paths, list):
+            raise TypeError("nzb_paths must be a list")
+        if not nzb_paths:
+            raise ValueError("nzb_paths must map to a non-empty list")
+        paths = [pathlib.Path(p) for p in nzb_paths]
         invalid_paths = [p for p in paths if not p.is_dir()]
         if invalid_paths:
             raise NotADirectoryError(
@@ -163,9 +168,14 @@ class NzbPasswordPlugin(PasswordPlugin):
             for file in files:
                 full_path: pathlib.Path = nzb_directory / root / file
                 if full_path.suffix == ".nzb":
-                    title_password = NzbPasswordPlugin._process_file(
-                        full_path, read_file_content=lambda fp: open(fp, "r").read()
-                    )
+                    try:
+                        title_password = NzbPasswordPlugin._process_file(
+                            full_path,
+                            read_file_content=lambda fp: open(fp, "r").read(),
+                        )
+                    except (OSError, UnicodeDecodeError) as exc:
+                        logger.warning("Skipping unreadable NZB %s: %s", full_path, exc)
+                        continue
                     if title_password:
                         dir_store.add_password(*title_password)
                 elif full_path.suffix == ".rar":
@@ -174,12 +184,21 @@ class NzbPasswordPlugin(PasswordPlugin):
                     rar_file: RarArchive = RarArchive.from_path(nzb_directory, path)
                     for file_entry in rar_file.files:
                         logger.debug(f"Read {file_entry.path}... extracting passwords")
-                        title_password = NzbPasswordPlugin._process_file(
-                            file_entry.path,
-                            read_file_content=lambda fp: rar_file.read_file(
-                                file_entry.path
-                            ),
-                        )
+                        try:
+                            title_password = NzbPasswordPlugin._process_file(
+                                file_entry.path,
+                                read_file_content=lambda fp: rar_file.read_file(
+                                    file_entry.path
+                                ),
+                            )
+                        except (OSError, UnicodeDecodeError, RarArchiveError) as exc:
+                            logger.warning(
+                                "Skipping unreadable archive entry %s in %s: %s",
+                                file_entry.path,
+                                full_path,
+                                exc,
+                            )
+                            continue
                         if title_password:
                             dir_store.add_password(*title_password)
         return dir_store

--- a/tests/test_nzb_plugin.py
+++ b/tests/test_nzb_plugin.py
@@ -7,6 +7,7 @@ import pathlib
 import pytest
 from hoarder.passwords import NzbPasswordPlugin, PasswordStore
 from hoarder.utils import TableFormatter
+from typeguard import suppress_type_checks
 
 logger = logging.getLogger("hoarder.tests.test_nzb_plugin")
 
@@ -39,3 +40,38 @@ def test_nzb_plugin(nzb_plugin: NzbPasswordPlugin) -> None:
 
     assert "debian-12.11.0-amd64-netinst.iso" in password_store
     assert password_store["debian-12.11.0-amd64-netinst.iso"] == set(["guessme"])
+
+
+def test_nzb_plugin_requires_list_nzb_paths(tmp_path: pathlib.Path) -> None:
+    with pytest.raises(KeyError, match="nzb_paths"):
+        NzbPasswordPlugin({})
+
+    with pytest.raises(ValueError, match="nzb_paths"):
+        NzbPasswordPlugin({"nzb_paths": []})
+
+
+@suppress_type_checks
+def test_nzb_plugin_rejects_non_list_nzb_paths(tmp_path: pathlib.Path) -> None:
+    """A bare string is iterable char-by-char; it must be rejected."""
+    with pytest.raises(TypeError, match="nzb_paths"):
+        NzbPasswordPlugin({"nzb_paths": str(tmp_path)})  # type: ignore[arg-type]
+
+
+def test_nzb_plugin_skips_unreadable_nzb_and_continues(
+    tmp_path: pathlib.Path,
+) -> None:
+    """A file that can't be read/decoded must not stop extraction of the rest."""
+    good_nzb = tmp_path / "good-download{{secret123}}.nzb"
+    good_nzb.write_text("<nzb></nzb>")
+
+    # No {{password}} in the name, so extraction falls through to reading the
+    # file content, which is where the invalid UTF-8 bytes blow up.
+    broken_nzb = tmp_path / "broken-download.nzb"
+    broken_nzb.write_bytes(b"\xff\xfe not valid utf-8")
+
+    plugin = NzbPasswordPlugin({"nzb_paths": [str(tmp_path)]})
+    password_store = plugin.extract_passwords()
+
+    assert "good-download" in password_store
+    assert password_store["good-download"] == set(["secret123"])
+    assert "broken-download" not in password_store


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of unreadable NZB and archive content so processing continues when individual files or entries can’t be read.
  * Added clearer validation for NZB path settings, including rejecting empty lists and invalid non-list values.
* **Tests**
  * Expanded test coverage for invalid configuration values and unreadable file scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->