### PR TITLE
Use `type: ignore[dict-item]` annotation :gear: 

### DIFF
--- a/tests/test_nzb_plugin.py
+++ b/tests/test_nzb_plugin.py
@@ -54,7 +54,7 @@ def test_nzb_plugin_requires_list_nzb_paths(tmp_path: pathlib.Path) -> None:
 def test_nzb_plugin_rejects_non_list_nzb_paths(tmp_path: pathlib.Path) -> None:
     """A bare string is iterable char-by-char; it must be rejected."""
     with pytest.raises(TypeError, match="nzb_paths"):
-        NzbPasswordPlugin({"nzb_paths": str(tmp_path)})  # type: ignore[arg-type]
+        NzbPasswordPlugin({"nzb_paths": str(tmp_path)})  # type: ignore[dict-item]
 
 
 def test_nzb_plugin_skips_unreadable_nzb_and_continues(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated an automated test annotation to match current type-checking expectations.
  * No functional behavior, user experience, or runtime logic changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->